### PR TITLE
Update to fix broken build on melodic

### DIFF
--- a/rqt_example_cpp/src/rqt_example_cpp/my_plugin.cpp
+++ b/rqt_example_cpp/src/rqt_example_cpp/my_plugin.cpp
@@ -59,4 +59,4 @@ void triggerConfiguration()
 }*/
 
 }  // namespace rqt_example_cpp
-PLUGINLIB_DECLARE_CLASS(rqt_example_cpp, MyPlugin, rqt_example_cpp::MyPlugin, rqt_gui_cpp::Plugin)
+PLUGINLIB_EXPORT_CLASS(rqt_example_cpp::MyPlugin, rqt_gui_cpp::Plugin)

--- a/rqt_example_cpp/src/rqt_example_cpp/my_plugin.ui
+++ b/rqt_example_cpp/src/rqt_example_cpp/my_plugin.ui
@@ -13,6 +13,19 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
+  <widget class="QPushButton" name="Test">
+   <property name="geometry">
+    <rect>
+     <x>120</x>
+     <y>70</y>
+     <width>98</width>
+     <height>27</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Original Name</string>
+   </property>
+  </widget>
  </widget>
  <resources/>
  <connections/>


### PR DESCRIPTION
The build is broken because the macro PLUGINLIB_DECLARE_CLASS() has been
replaced with PLUGINLIB_DECLARE_CLASS().

The other change is in rqt_example_cpp/src/rqt_example_cpp/my_plugin.ui
where I added a QPushButton so the cpp UI matches its Python
counterpart.